### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:10-alpine
 
 RUN apk --update --no-cache add \
-	git=2.15.3-r0 \
-	python=2.7.15-r2 \
-	make=4.2.1-r0 \
-	g++=6.4.0-r5
+	git=2.18.1-r0 \
+	python=2.7.15-r1 \
+	make=4.2.1-r2 \
+	g++=6.4.0-r9
 
 WORKDIR /app
 


### PR DESCRIPTION
- Uses the alpine base image (24mb vs 267mb for the full image).

- Copies package-lock.json before running npm install to get an exact
  match on the dependencies.

- Uses JSON notation for CMD to handle OS signals correctly. See:
  https://github.com/hadolint/hadolint/wiki/DL3025