### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.14-alpine
+FROM node:10.15.2-alpine
 
 RUN apk --update --no-cache add \
 	git=2.18.1-r0 \


### PR DESCRIPTION
Docker image builds from `node:10-alpine`
Now it's 10.15.3 that use alpine 3.9
This version of Alpine has no this software
```
        git=2.18.1-r0 \
        python=2.7.15-r1 \
        make=4.2.1-r2 \
        g++=6.4.0-r9
```
It's from more older Alpine 3.8

Latest version of node that use Alpine 3.8 is `node:10.15.2-alpine`