### PR TITLE
Change Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.2-alpine
+FROM node:10.15.3-alpine
 
 RUN apk --update --no-cache add git python make g++
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM node:10.15.2-alpine
 
-RUN apk --update --no-cache add \
-	git=2.18.1-r0 \
-	python=2.7.15-r2 \
-	make=4.2.1-r2 \
-	g++=6.4.0-r9
+RUN apk --update --no-cache add git python make g++
 
 WORKDIR /app
 


### PR DESCRIPTION
We stick to a specific base image version, so no need to specify git, python
and other packages version.

git 2.18.1-r0 has vulnerability CVE-2018-19486